### PR TITLE
set the build.linux.category option

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,10 @@
   },
   "build": {
     "productName": "Marv",
-    "icon": "app/static/icon.png"
+    "icon": "app/static/icon.png",
+    "linux": {
+      "category": "Streaming"
+    }
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
yarn v1.22.5
electron-builder 22.9.1

Pendant le build electron sous linux, un warning est déclenché pour renseigner la propriété build.linux.category (https://www.electron.build/configuration/linux)

>>> application Linux category is set to default "Utility"  reason=linux.category is not set and cannot map from macOS docs=https://www.electron.build/configuration/linux

La liste des categories pour les applications Linux est disponible ici: https://specifications.freedesktop.org/menu-spec/latest/apa.html#main-category-registry (malheureusement pas 'encore' de categorie streaming)

"build": {
    "productName": "Marv",
    "icon": "app/static/icon.png",
    "linux": {
      "category": "Streaming"
    }
  }