### PR TITLE
Remove SIGKILL signal handler

### DIFF
--- a/app/main/index.js
+++ b/app/main/index.js
@@ -59,4 +59,3 @@ app.on("quit", onQuit);
 
 process.on("SIGINT", onQuit);
 process.on("SIGTERM", onQuit);
-process.on("SIGKILL", onQuit);


### PR DESCRIPTION
This pull request removes the signal handler for the `SIGKILL` signal.

### Why are these changes necessary?

Registering a signal handler for this signal will cause Node.js to throw an error at load time on some OSes / Node.js versions.

```sh
App threw an error during load
Error: uv_signal_start EINVAL
    at process.startListeningIfSignal (internal/process/signal.js:35:13)
    at process.emit (events.js:315:20)
    at _addListener (events.js:358:14)
    at process.addListener (events.js:406:10)
    at Object.<anonymous> (/Users/hideo/Work/marv/app/main/index.js:62:9)
    at Module._compile (internal/modules/cjs/loader.js:1152:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1173:10)
    at Module.load (internal/modules/cjs/loader.js:992:32)
    at Module._load (internal/modules/cjs/loader.js:885:14)
    at Function.f._load (electron/js2c/asar_bundle.js:5:12694)
```

![Main error](https://i.imgur.com/pxbf9pv.png)

This is also visible in the renderer process:

![Renderer error](https://i.imgur.com/3C2CL27.png)

### How were these changes implemented?

[As documented](https://nodejs.org/api/process.html#process_signal_events), the `SIGKILL` signal **cannot** have a signal handler:

> `'SIGKILL'` cannot have a listener installed, it will unconditionally terminate Node.js on all platforms.

Removing the signal handler is enough to fix the issue.

### Why is this not an issue on all machines?

As stated [in the documentation](https://nodejs.org/api/process.html#process_signal_events), `Windows does not support signals so has no equivalent to termination by signal`, this signal handler doesn't even register on this platform.

Regarding Linux & macOS, it's also possible to not encounter this issue as explained in [the archive of the old Node.js repo](https://github.com/nodejs/node-v0.x-archive/issues/6339#issuecomment-26193660) due to the fact that old Node.js version allowed this signal handler to be registered without throwing an error even if the handler was not working.

### Does this change affect the behavior of the application?

No, as it's not possible to catch `SIGKILL` from Node.js, this handler was useless.