### PR TITLE
Fix Twitch login issue on various platforms

### DIFF
--- a/app/server/libs/twitch/AuthProvider.js
+++ b/app/server/libs/twitch/AuthProvider.js
@@ -42,11 +42,9 @@ module.exports = class AuthProvider {
   }
 
   getAuthUrl(scopes) {
-    const redir = encodeURIComponent(this.redirectURI);
-
-    return (
+    return encodeURI(
       `${authBaseURL}&client_id=${this.clientId}` +
-      `&redirect_uri=${redir}&scope=${scopes.join(" ")}` +
+      `&redirect_uri=${this.redirectURI}&scope=${scopes.join(" ")}` +
       `&force_verify=${this.forceVerify ? "true" : "false"}`
     );
   }


### PR DESCRIPTION
This pull request properly encodes the entire URI used to login with Twitch.

### Why are these changes necessary?

On some platforms / environments (e.g. macOS Big Sur 11.2.1 + Edge 90.0.810.1), [`open`](https://www.npmjs.com/package/open), the npm package used to open various URLs will fail **silently** to open the Twitch login URL as it's not entirely encoded.

As it's failing silently, nothing happens except an infinite loader that will hangs forever, for example, in the browser:

![Browser issue](https://i.imgur.com/psTlMYd.gif)

Same goes for the application:

![App issue](https://i.imgur.com/um6MWzh.gif)

### How were these changes implemented?

Properly encoding the entire URI using [`encodeURI()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURI) is enough to fix the issue.

![Fix](https://i.imgur.com/UG4xaEI.gif)

### Does this change affect the behavior of the application?

This shouldn't, I tested the change on Linux & macOS and it works as expected, altho I didn't manage to test on Windows as I don't have a Windows machine available.