### PR TITLE
Save and restore the maximized state of the Marv window

### DIFF
--- a/app/main/window/storeBounds.js
+++ b/app/main/window/storeBounds.js
@@ -12,8 +12,14 @@ module.exports = function storeBounds({ win, name, delay = 500 } = {}) {
 
   let timeout = null;
 
-  const loadBounds = () => win.setBounds(store.get("bounds"));
-  const updateBounds = () => store.set("bounds", win.getBounds());
+  const loadBounds = () => {
+    win.setBounds(store.get("bounds"));
+    if (store.get("fullscreen")) win.maximize();
+  };
+  const updateBounds = () => {
+    store.set("bounds", win.getBounds());
+    store.set("fullscreen", win.isMaximized());
+  };
 
   const updateBoundsDelay = () => {
     timeout && clearTimeout(timeout);


### PR DESCRIPTION
Après avoir fait plusieurs essais j'ai trouvé où étaient sauvegardé la position et la taille de la fenêtre de Marv.
J'ai donc sauvegardé en plus l'état à restaurer si la fenêtre est mise en plein écran :)

Discussion en relation: https://github.com/skarab42/marv/discussions/215